### PR TITLE
Require Webpack-built frigging-bootstrap...

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -35,25 +35,12 @@ module.exports = {
     path: isProduction ? './dist' : './examples',
     filename: '[name].js',
   },
-  resolve: {
-    alias: {
-      react: path.resolve('./node_modules/react'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-      frig: path.resolve('./node_modules/frig/src/index.js'),
-      'frigging-bootstrap': path.resolve(
-        './node_modules/frigging-bootstrap/src/js/index.js'
-      ),
-    },
-  },
   devServer: {
     contentBase: './src',
   },
   module: {
     loaders: [
       {
-        test: /\.styl$/,
-        loader: 'style-loader!css-loader!stylus-loader',
-      }, {
         test: /\.jsx?$/,
         loader: 'babel',
         query: {


### PR DESCRIPTION
frigging-examples will now load Frig and Frigging-Bootstrap normally, as it would any other node_module.

Prior to this commit we were including frigging-bootstrap by reaching into node_modules and grabbing it's index.js file. This bypassed Frigging Bootstrap's webpack build process. Since we skipped frigging-bootstrap's build process, frigging-examples had to load `.styl` files on behalf of `frigging-bootstrap`. This configuration was complex, and as of `frigging-bootstrap` 0.12.0 is no longer necessary.
